### PR TITLE
fix: typo OPENAI_API_KEY in README.md

### DIFF
--- a/examples/conversation_with_memory/README.md
+++ b/examples/conversation_with_memory/README.md
@@ -6,7 +6,7 @@ PLaMo beta (2024/08/20時点)での最大コンテクスト長は4096トーク�
 
 ## 使い方
 
-まず、環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
+まず、環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>

--- a/examples/function_calling_basic/README.md
+++ b/examples/function_calling_basic/README.md
@@ -13,7 +13,7 @@ get_current_feather(location: string, unit: string)
 
 ## 使い方
 
-まず、環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
+まず、環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>

--- a/examples/named_entity_extraction/README.md
+++ b/examples/named_entity_extraction/README.md
@@ -7,7 +7,7 @@ Function Callingの機能を利用して、入力テキストから特定の種�
 
 ## 使い方
 
-まず、環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
+まず、環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>

--- a/examples/rephrase_quiz/README.md
+++ b/examples/rephrase_quiz/README.md
@@ -5,7 +5,7 @@ Rephrase Quiz
 
 ## 使い方
 
-まず、環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
+まず、環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行なって入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>

--- a/examples/simple_examples/langchain/README.md
+++ b/examples/simple_examples/langchain/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ### 環境変数の設定
 
-環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行ない、入手したAPIキーをセットしてください。
+環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行ない、入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>

--- a/examples/simple_examples/openai/README.md
+++ b/examples/simple_examples/openai/README.md
@@ -13,7 +13,7 @@ pip install -r requirements.txt
 
 ### 環境変数の設定
 
-環境変数 `OPEAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行ない、入手したAPIキーをセットしてください。
+環境変数 `OPENAI_API_KEY` に、[PLaMo β版 トライアル](https://plamo.preferredai.jp/)で申し込みを行ない、入手したAPIキーをセットしてください。
 
 ```sh
 export OPENAI_API_KEY=<YOUR_API_KEY>


### PR DESCRIPTION
fix typo "OPEAI_API_KEY " in README